### PR TITLE
fix(navbar): Update Bootstrap attributes for mobile view

### DIFF
--- a/ng_serve_output.log
+++ b/ng_serve_output.log
@@ -1,3 +1,0 @@
-
-> ssms-customer-portal@0.0.0 start
-> ng serve

--- a/src/app/components/shared/navbar/navbar.component.html
+++ b/src/app/components/shared/navbar/navbar.component.html
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
   <div class="container">
     <a class="navbar-brand" routerLink="/">ADrenaline Sports Store</a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
       aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>


### PR DESCRIPTION
The navbar was not collapsing correctly in the mobile view because it was using Bootstrap 4 data attributes (`data-toggle`, `data-target`) with Bootstrap 5. This commit updates the attributes to the correct Bootstrap 5 versions (`data-bs-toggle`, `data-bs-target`).

Due to persistent timeout issues in the development environment, I was unable to fully verify this fix by running the application. However, the change is a standard and well-documented solution for this specific version incompatibility.