### PR TITLE
feat: Update logic for Newly Added and Special Offers sections

### DIFF
--- a/src/app/customer-home/customer-home.component.ts
+++ b/src/app/customer-home/customer-home.component.ts
@@ -44,9 +44,15 @@ export class CustomerHomeComponent implements OnInit {
     this.customerHomeService.getHomeData().subscribe(data => {
       this.products = data.products.filter(product => product.canListed === true);
 
-      // Populate newly added and special offer products
-      this.newlyAddedProducts = this.products.slice(0, 8);
-      this.specialOfferProducts = this.products.slice(8, 16);
+      // Populate newly added products
+      this.newlyAddedProducts = [...this.products]
+        .sort((a, b) => new Date(b.created_date).getTime() - new Date(a.created_date).getTime())
+        .slice(0, 10);
+
+      // Populate special offer products
+      this.specialOfferProducts = this.products
+        .filter(p => p.offerId)
+        .slice(0, 10);
 
       // Extract unique categories from the products
       const categoryMap = new Map<string, Category>();

--- a/src/app/customer-home/data/product-model.ts
+++ b/src/app/customer-home/data/product-model.ts
@@ -27,6 +27,7 @@ export interface Product {
   discountedPrice: number;
   offerPrice: number;
   offerName: string; // Added to include offer name
+  created_date: Date;
 }
 
 export interface Quantities {


### PR DESCRIPTION
This commit updates the logic for populating the "Newly Added" and "Special Offers" sections on the customer home page.

- The "Newly Added" section now displays the 10 most recent products based on their `created_date`.
- The "Special Offers" section now displays 10 products that have an offer associated with them.
- The `Product` interface has been updated to include the `created_date` property.