### PR TITLE
feat: Add Sale page with offered products

### DIFF
--- a/ng_serve_output.log
+++ b/ng_serve_output.log
@@ -1,5 +1,0 @@
-Component HMR has been enabled.
-If you encounter application reload issues, you can manually reload the page to bypass HMR and/or disable this feature with the `--no-hmr` command line option.
-Please consider reporting any issues you encounter here: https://github.com/angular/angular-cli/issues
-
-❯ Building...

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,10 +2,12 @@ import { Routes } from '@angular/router';
 import { AboutComponent } from './components/about/about.component';
 import { ContactComponent } from './components/contact/contact.component';
 import { CustomerHomeComponent } from './customer-home/customer-home.component';
+import { SaleComponent } from './components/sale/sale.component';
 
 export const routes: Routes = [
     { path: '', redirectTo: '/home', pathMatch: 'full' },
      {path: 'home', component: CustomerHomeComponent },
     { path: 'about', component: AboutComponent },
     { path: 'contact', component: ContactComponent },
+    { path: 'sale', component: SaleComponent },
   ];

--- a/src/app/components/sale/sale.component.html
+++ b/src/app/components/sale/sale.component.html
@@ -1,0 +1,120 @@
+<!-- Hero Section -->
+<div class="hero-section text-center text-white bg-dark py-5">
+  <div class="container">
+    <h1 class="display-4">Sale</h1>
+    <p class="lead">Check out our products on sale!</p>
+  </div>
+</div>
+
+<div class="container my-4">
+  <!-- All Products Section -->
+  <section>
+    <h2 class="section-title mb-4">Products on Sale</h2>
+    <!-- Filter Section -->
+    <div class="row mb-4">
+      <div class="col-md-4 mb-2">
+        <input type="text" class="form-control" placeholder="Search by product name" [(ngModel)]="searchName" (input)="applyFilters()">
+      </div>
+      <div class="col-md-4 mb-2">
+        <select class="form-control" [(ngModel)]="selectedCategory" (ngModelChange)="applyFilters()">
+          <option value="">All Categories</option>
+          <option *ngFor="let category of categories" [value]="category.name">{{ category.name }}</option>
+        </select>
+      </div>
+      <div class="col-md-4 mb-2">
+        <select class="form-control" [(ngModel)]="selectedSize" (ngModelChange)="applyFilters()">
+          <option value="">All Sizes</option>
+          <option *ngFor="let size of sizes" [value]="size">{{ size }}</option>
+        </select>
+      </div>
+    </div>
+
+    <!-- Products Grid with Pagination -->
+    <div class="row">
+      <div *ngFor="let product of filteredProducts | paginate: { itemsPerPage: 12, currentPage: p }" class="col-md-3 mb-4 d-flex align-items-stretch">
+        <div class="card w-100">
+          <img [src]="product.imageUrl" class="card-img-top" alt="{{ product.name }}">
+          <div class="card-body d-flex flex-column">
+            <h5 class="card-title">{{ product.name }}</h5>
+            <p class="card-text">Category: {{ product.category.name }}</p>
+            <div *ngIf="product.offerId">
+              <p class="card-text text-danger">
+                <span>{{ product.offerName }}</span>
+              </p>
+              <p class="card-text font-weight-bold">
+                <del>{{ product.sellingPrice | currency }}</del>
+                <strong>{{ product.discountedPrice | currency }}</strong>
+              </p>
+              <p class="card-text">
+                <small class="text-muted">Offer Price: {{ product.offerPrice | currency }}</small>
+              </p>
+            </div>
+            <p *ngIf="!product.offerId" class="card-text font-weight-bold">
+              {{ product.sellingPrice | currency }}
+            </p>
+            <button class="btn btn-primary mt-auto" (click)="openBuyModal(product)">Add to Cart</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Pagination Controls -->
+    <div class="d-flex justify-content-center">
+      <pagination-controls (pageChange)="p = $event"></pagination-controls>
+    </div>
+
+    <!-- If no products found -->
+    <div *ngIf="filteredProducts.length === 0" class="text-center">
+      <p>No products found.</p>
+    </div>
+  </section>
+</div>
+
+<!-- Modal for Product Details -->
+<div *ngIf="selectedProduct" class="modal show fade d-block" tabindex="-1" [ngStyle]="{'background-color': 'rgba(0,0,0,0.5)'}">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+         <h5 class="modal-title">{{ selectedProduct.name }}</h5>
+         <button type="button" class="close" (click)="closeBuyModal()">&times;</button>
+      </div>
+      <div class="modal-body">
+         <img [src]="selectedProduct.imageUrl" alt="{{ selectedProduct.name }}" class="img-fluid mb-3">
+         <p><strong>Category:</strong> {{ selectedProduct.category.name }}</p>
+         <div *ngIf="selectedProduct.offerId">
+           <p>
+             <span>{{ selectedProduct.offerName }}</span>
+           </p>
+           <p>
+             <strong>Price:</strong>
+             <del>{{ selectedProduct.sellingPrice | currency }}</del>
+             <strong>{{ selectedProduct.discountedPrice | currency }}</strong>
+           </p>
+           <p>
+             <small class="text-muted">Offer Price: {{ selectedProduct.offerPrice | currency }}</small>
+           </p>
+         </div>
+         <p *ngIf="!selectedProduct.offerId">
+           <strong>Price:</strong> {{ selectedProduct.sellingPrice | currency }}
+         </p>
+         <!-- Size Selection (Mandatory) using sizeMap -->
+         <div class="form-group">
+          <label for="sizeSelect"><strong>Select Size:</strong></label>
+          <select id="sizeSelect" class="form-control" [(ngModel)]="selectedSizeInModal">
+            <option value="" disabled>Select size</option>
+            <option
+              *ngFor="let sizeEntry of selectedProduct.sizeMap"
+              [value]="sizeEntry.size"
+              [disabled]="sizeEntry.quantity === 0">
+              {{ sizeEntry.size }} (Available: {{ sizeEntry.quantity }})
+            </option>
+          </select>
+        </div>
+      </div>
+      <div class="modal-footer">
+         <button class="btn btn-success" (click)="addToCart()">Add to Cart</button>
+         <button class="btn btn-secondary" (click)="closeBuyModal()">Cancel</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/components/sale/sale.component.spec.ts
+++ b/src/app/components/sale/sale.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SaleComponent } from './sale.component';
+
+describe('SaleComponent', () => {
+  let component: SaleComponent;
+  let fixture: ComponentFixture<SaleComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SaleComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SaleComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/sale/sale.component.ts
+++ b/src/app/components/sale/sale.component.ts
@@ -1,0 +1,118 @@
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { NgxPaginationModule } from 'ngx-pagination';
+import { CustomerHomeService } from '../../customer-home/services/customer-view.service';
+import { Category, Product } from '../../customer-home/data/product-model';
+import { CartService } from '../../cart/cart.service';
+import { CartItem } from '../../cart/cart.model';
+
+@Component({
+  selector: 'app-sale',
+  templateUrl: './sale.component.html',
+  styleUrls: ['./sale.component.css'],
+  standalone: true,
+  imports: [
+    FormsModule,
+    CommonModule,
+    NgxPaginationModule,
+  ],
+})
+export class SaleComponent implements OnInit {
+  products: Product[] = [];
+  filteredProducts: Product[] = [];
+  categories: Category[] = [];
+  sizes: string[] = [];
+  searchName: string = '';
+  selectedCategory: string = '';
+  selectedSize: string = ''; // For size filter
+  p: number = 1; // current page for pagination
+
+  // Property to store the product selected for purchase
+  selectedProduct: Product | null = null;
+  // Renamed for clarity, this is for the size selection in the modal
+  selectedSizeInModal: string = '';
+
+  constructor(
+    private customerHomeService: CustomerHomeService,
+    private cartService: CartService
+  ) { }
+
+  ngOnInit(): void {
+    this.customerHomeService.getHomeData().subscribe(data => {
+      // Filter for products that have an offer and are listable
+      this.products = data.products.filter(product => product.canListed === true && product.offerId);
+
+      // Extract unique categories from the products
+      const categoryMap = new Map<string, Category>();
+      this.products.forEach(product => {
+        const category = product.category;
+        if (category && category.name) {
+          if (!categoryMap.has(category.name)) {
+            const randomId = Math.floor(Math.random() * 9000) + 1000;
+            categoryMap.set(category.name, {
+              id: randomId,
+              name: category.name,
+              description: category.description || ''
+            });
+          }
+        }
+      });
+      this.categories = Array.from(categoryMap.values());
+
+      // Extract unique, available sizes from the products
+      const sizeSet = new Set<string>();
+      this.products.forEach(product => {
+        product.sizeMap.forEach(sizeEntry => {
+          if (sizeEntry.quantity > 0) {
+            sizeSet.add(sizeEntry.size);
+          }
+        });
+      });
+      this.sizes = Array.from(sizeSet).sort();
+
+      this.applyFilters();
+    });
+  }
+
+  applyFilters(): void {
+    this.filteredProducts = this.products.filter(product => {
+      const matchName = product.name.toLowerCase().includes(this.searchName.toLowerCase());
+      const matchCategory = this.selectedCategory
+        ? product.category.name === this.selectedCategory
+        : true;
+      const matchSize = this.selectedSize
+        ? product.sizeMap.some(s => s.size === this.selectedSize && s.quantity > 0)
+        : true;
+      return matchName && matchCategory && matchSize;
+    });
+    this.p = 1; // reset pagination when filters change
+  }
+
+  openBuyModal(product: Product): void {
+    this.selectedProduct = product;
+    this.selectedSizeInModal = ''; // Reset modal-specific size
+  }
+
+  closeBuyModal(): void {
+    this.selectedProduct = null;
+    this.selectedSizeInModal = '';
+  }
+
+  addToCart(): void {
+    if (!this.selectedProduct || !this.selectedSizeInModal) {
+      alert('Please select a size.');
+      return;
+    }
+
+    const cartItem: CartItem = {
+      product: this.selectedProduct,
+      size: this.selectedSizeInModal,
+      quantity: 1, // Defaulting to 1, can be extended later
+    };
+
+    this.cartService.addToCart(cartItem);
+    this.closeBuyModal();
+    alert('Product added to cart!'); // Optional: provide feedback to the user
+  }
+}

--- a/src/app/components/shared/navbar/navbar.component.html
+++ b/src/app/components/shared/navbar/navbar.component.html
@@ -11,6 +11,9 @@
           <a class="nav-link" routerLink="/" routerLinkActive="activebutton" ariaCurrentWhenActive="page">Home</a>
         </li>
         <li class="nav-item">
+          <a class="nav-link" routerLink="/sale" routerLinkActive="activebutton" ariaCurrentWhenActive="page">Sale</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" routerLink="/about" routerLinkActive="activebutton" ariaCurrentWhenActive="page">About</a>
         </li>
         <li class="nav-item">

--- a/src/app/components/shared/navbar/navbar.component.ts
+++ b/src/app/components/shared/navbar/navbar.component.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
-import { CartService } from '../../../../cart/cart.service';
+import { CartService } from '../../../cart/cart.service';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { CommonModule } from '@angular/common';
+import { CartItem } from '../../../cart/cart.model';
 
 @Component({
   selector: 'app-navbar',
@@ -17,7 +18,7 @@ export class NavbarComponent {
 
   constructor(private cartService: CartService) {
     this.cartItemCount$ = this.cartService.items$.pipe(
-      map(items => items.reduce((acc, item) => acc + item.quantity, 0))
+      map((items: CartItem[]) => items.reduce((acc, item) => acc + item.quantity, 0))
     );
   }
 


### PR DESCRIPTION
- Created a new 'Sale' page to display products with offers.
- The page includes filters for product name, category, and size.
- Pagination is implemented for the product list.
- The "Add to Cart" functionality is the same as the home page.
- Added a link to the 'Sale' page in the navigation bar.
- Fixed a few minor issues in existing components.