### PR TITLE
feat: Add brand logo to the navigation bar

### DIFF
--- a/src/app/components/shared/navbar/navbar.component.html
+++ b/src/app/components/shared/navbar/navbar.component.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
   <div class="container">
-    <a class="navbar-brand" routerLink="/">ADrenaline Sports Store</a>
+    <a class="navbar-brand" routerLink="/"><img src="assets/logo.jpg" alt="ADrenaline Sports Store logo" height="30"></a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
       aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
This commit updates the navigation bar to display the company logo. The change replaces the "ADrenaline Sports Store" text with an image of the logo, improving brand visibility. The logo is sourced from `assets/logo.jpg`.